### PR TITLE
Adding Malta + Backup chart if map isn't available

### DIFF
--- a/webapp/countries.json
+++ b/webapp/countries.json
@@ -192,6 +192,14 @@
         "regions": {}
     },
     {
+        "name": "Malta",
+        "code": "mt",
+        "first date": "10-10-2023",
+        "currency": "EUR",
+        "currency symbol": "€",
+        "regions": {}
+    },
+    {
         "name": "Netherlands",
         "code": "nl",
         "first date": "10-10-2023",

--- a/webapp/country_states.js
+++ b/webapp/country_states.js
@@ -532,6 +532,16 @@ const lv = new Map([
     ["Vidzeme", "Vidzeme"],
 ]);
 
+const mt = new Map([
+    ["Unknown", "N/A"],
+    ["Northern Region", "Northern"], 
+    ["Central Region", "Central"], 
+    ["Gozo", "Gozo"], 
+    ["South Eastern Region", "South Eastern"], 
+    // Meta's data should have Southern Region as well, but for some reason it doesn't
+    // If in the future it is added properly, make sure to include it here
+]);
+
 const nl = new Map([
     ["Unknown", "N/A"],
     ["Zeeland", "NL.ZE"],
@@ -797,6 +807,7 @@ const maps = {
     'lt': lt,
     'lu': lu,
     'lv': lv,
+    'mt': mt,
     'nl': nl,
     'ph': ph,
     'pl': pl,

--- a/webapp/views/partials/statemap.ejs
+++ b/webapp/views/partials/statemap.ejs
@@ -78,6 +78,128 @@
             }
         }
 
+        drawBackup() {
+            console.log("BACKUP!")
+            let _d = this.data
+            let _pageName = this.pageName
+            let _funder = this.funder
+            let _mapName = this.mapName
+            
+            const margin = { top: 20, right: 40, bottom: 40, left: 100 };
+		    var height = 400 - margin.top - margin.bottom
+            const width = d3.select(`#${_mapName}`).node().getBoundingClientRect().width - margin.right - margin.left;
+            
+            d3.select(`#${_mapName}`).html("");
+
+            const svg = d3.select(`#${_mapName}`)
+                .append("svg")
+                .attr("width", width + margin.left + margin.right)
+                .attr("height", height + margin.top + margin.bottom)
+                .append("g")
+                .attr("transform", `translate(${margin.left},${margin.top})`);
+
+            const x = d3.scaleLinear()
+                .domain([0, 1])  // scales [0 > 1] to [0% > 100%]
+                .range([0, width]);
+
+            const y = d3.scaleBand()
+                .domain(_d.map(d => d.name))
+                .range([0, height])
+                .padding(1);
+
+            svg.append("g")
+                .attr("transform", `translate(0,${height})`)
+                .call(d3.axisBottom(x).tickFormat(d3.format(".0%"))) // Format as percentage
+            
+            // wrap functino taken from: https://gist.github.com/mbostock/7555321
+            function wrap(text, width) {
+                text.each(function() {
+                    var text = d3.select(this),
+                        words = text.text().split(/\s+/).reverse(),
+                        word,
+                        line = [],
+                        lineNumber = 0,
+                        lineHeight = 1.1, // ems
+                        y = text.attr("y"),
+                        dy = parseFloat(text.attr("dy")),
+                        xOffset = -8,
+                        tspan = text.text(null).append("tspan").attr("x", xOffset).attr("y", y).attr("dy", dy + "em");
+                    while (word = words.pop()) {
+                    line.push(word);
+                    tspan.text(line.join(" "));
+                    if (tspan.node().getComputedTextLength() > width) {
+                        line.pop();
+                        tspan.text(line.join(" "));
+                        line = [word];
+                        tspan = text.append("tspan").attr("x", xOffset).attr("y", y).attr("dy", ++lineNumber * lineHeight + dy + "em").text(word);
+                    }
+                    }
+                });
+            }
+
+            svg.append("g")
+                .call(d3.axisLeft(y).tickFormat(function(d) { return d; }))
+                .selectAll(".tick text")
+                .call(wrap, margin.left); // Apply the wrap function for cases of large region names
+            
+            // Generate lines for the lollipops
+            svg.selectAll(".line")
+                .data(_d)
+                .enter()
+                .append("line")
+                .attr("class", "line")
+                .attr("x1", x(0))
+                .attr("x2", d => x(d.value))
+                .attr("y1", d => y(d.name))
+                .attr("y2", d => y(d.name))
+                .attr("stroke", "black") 
+                .attr("stroke-width", 1)
+                .attr("transform", "translate(0, 0.5)");
+
+            // Generate circles for the lollipop
+            svg.selectAll(".circle")
+                .data(_d)
+                .enter()
+                .append("circle")
+                .attr("class", "circle")
+                .attr("cx", d => x(d.value))
+                .attr("cy", d => y(d.name))
+                .attr("r", 5);
+
+            // Text labels for values, position at the circle of lollipop
+            svg.selectAll(".label")
+                .data(_d)
+                .enter()
+                .append("text")
+                .attr("class", "label")
+                .attr("x", function(d) {
+                    if (d.value > 0.9) {
+                        return x(d.value) - 10;
+                    }
+                    return x(d.value) + 10;
+                })  
+                .attr("y", function(d) {
+                    if (d.value > 0.9) {
+                        return y(d.name) - 10;
+                    }
+                    return y(d.name);
+                })
+                .text(d => (d.value * 100).toFixed(2) + "%");
+            
+            svg.append("text")
+                .attr("transform", "translate(" + (width / 2) + " ," + (height + margin.top + 20) + ")")
+                .style("text-anchor", "middle")
+                .text("Averaged audience for ads, (in %)");
+
+            d3.select('#map_loader').style('display', 'none');
+
+            d3.select(`#${this.mapName}`)
+                .style("visibility", "visible")
+                .style("display", "flex");
+
+            d3.select("#learnmore-map li:first-child").html("<b style='font-weight: bold;'>Map is unavailable for this country</b>, the same data is reflected in the lollipop chart below.");
+        }
+
         draw() {  
             let _d = this.data
             let _pageName = this.pageName
@@ -780,7 +902,12 @@
                     .style("visibility", "visible")
                     .style("display", "flex");
 
-            });
+            }).catch(error => {
+                // Should a map not be present, default to drawing a Lollipop graph, handled in drawBackup()
+                console.error("Error fetching topo data:", error);
+                this.drawBackup();
+                return;
+            });;
 
             ////////////////////////////////////////
             // -- FINISHED PROCESSING MAP DATA -- //

--- a/webapp/views/partials/summary.ejs
+++ b/webapp/views/partials/summary.ejs
@@ -183,7 +183,7 @@
 						<div class="dropdown-content dropdown-content-navigation" style="display:none; border: 1px solid lightgrey; box-shadow: none; padding: 0px;">
 							<div class="navigation-instructions" id="right-navigation-instructions">
 								<p id="tiptext-map"></p>
-								<ul>
+								<ul id="learnmore-map">
 									<li>Hover over any location on the map to view what percentages of an advertiser’s ad audience came from that location.</li>
 									<li>For every social issues, elections or politics related ad, Meta provides a detailed breakdown of the location(s) of the ad’s audience as a percentage of the total audience. For example, for a hypothetical Ad #1, Meta will report what percentage of the total audience came from each of the various locations where the ad was shown.</li>
 									<li>Meta assigned people’s location based on where they or their device connected to the internet and/or based on information in their account profile.</li>
@@ -535,9 +535,8 @@
 		});
 
 		performRequest('/facebook_ads_v2/funder_map', commonData, data => {
-			// drawMap(data);
 			mapData = data;
-			rawMap = new Statemap(data, "chart-container", country, mainFunder); // TO DO
+			rawMap = new Statemap(data, "chart-container", country, mainFunder);
 			prevRawMap = rawMap;
 		});
 
@@ -667,6 +666,7 @@
 		d3.select('#funder_pages_loader').style('display', 'block');
 		d3.select('#demographics_loader').style('display', 'block');
 		d3.select('#timeline_loader').style('display', 'block');
+		d3.select('#chart-container').html('<div id="map-tooltip"><div id="map-close"></div></div>');
 		d3.select('#map_loader').style('display', 'block');	
 		d3.select('#wordmap_loader').style('display', 'none'); // User has to select an option before the loader becomes visible
 		d3.select('#funder_pages').html('');
@@ -728,7 +728,7 @@
 		d3.select('#map_loader').style('display', 'block')
 		d3.select('#timeline').html('')
 		
-		d3.select("#chart-container").style("display", "none")
+		d3.select('#chart-container').html('<div id="map-tooltip"><div id="map-close"></div></div>');
 		d3.select('#regions_loader').style('display', 'block')
 		
 		$([document.documentElement, document.body]).animate({
@@ -774,7 +774,6 @@
 				performRequest('/facebook_ads_v2/funder_map', commonData, data => {
 					rawMap = new Statemap(data, "chart-container", country, mainFunder, p.page_name);
 				});
-				//drawMap(pageFilter(mapData))
 			} catch (err) {
 				console.log(err);
 			}


### PR DESCRIPTION
It was difficult to find a free resource of a map for Malta that lined up with the data presented from Meta (it seems to follow the [region format from 2009-2021](https://en.wikipedia.org/wiki/Regions_of_Malta#Former_regions_(2009-2021)))

As a result I added a backup chart to be used instead if a TopoJSON map isn't provided. It is just a simple lollipop chart built with d3.js.

Also setting the display to none for the #chart-container tag would break the width for this new drawBackup() function, so I had to update the clearing of the chart by doing the following: (which improved the behaviour in general as well).

`d3.select('#chart-container').html('<div id="map-tooltip"><div id="map-close"></div></div>');`

> As a side note, from the ads I have collected from Malta, whenever it gives us all the regions, it doesn't seem to include the Southern Region as part of the collection (just the other 4 are shown). I am unsure if this is an intended structure, but it is odd that it doesn't line up with any standard I could find.